### PR TITLE
Fix: Update balance on transaction edit

### DIFF
--- a/client/src/pages/card-detail.tsx
+++ b/client/src/pages/card-detail.tsx
@@ -35,6 +35,13 @@ export default function CardDetail() {
     }
   };
 
+  const handleTransactionEdited = () => {
+    if (params?.id) {
+      const updatedCard = storage.getCard(params.id);
+      setCard(updatedCard || null);
+    }
+  };
+
   const handleBack = () => {
     setLocation("/");
   };
@@ -132,7 +139,7 @@ export default function CardDetail() {
                 transaction={transaction}
                 cardId={card.id}
                 onDelete={handleTransactionDeleted}
-                onEdit={handleTransactionDeleted}
+                onEdit={handleTransactionEdited}
               />
             ))}
           </div>


### PR DESCRIPTION
The current balance was not being updated when a transaction was edited. This was because the `onEdit` event handler was incorrectly wired to the `handleTransactionDeleted` function.

This commit introduces a new `handleTransactionEdited` function in `card-detail.tsx` and wires it to the `onEdit` prop of the `TransactionItem` component. This ensures that the card's state is refreshed and the balance is recalculated after a transaction is edited.