### PR TITLE
Fix: Update balance on transaction edit

### DIFF
--- a/client/src/pages/card-detail.tsx
+++ b/client/src/pages/card-detail.tsx
@@ -23,7 +23,7 @@ export default function CardDetail() {
   const handleTransactionAdded = () => {
     if (params?.id) {
       const updatedCard = storage.getCard(params.id);
-      setCard(updatedCard || null);
+      setCard(updatedCard ? { ...updatedCard, transactions: [...updatedCard.transactions] } : null);
       setShowAddModal(false);
     }
   };
@@ -31,14 +31,15 @@ export default function CardDetail() {
   const handleTransactionDeleted = () => {
     if (params?.id) {
       const updatedCard = storage.getCard(params.id);
-      setCard(updatedCard || null);
+      setCard(updatedCard ? { ...updatedCard, transactions: [...updatedCard.transactions] } : null);
     }
   };
 
   const handleTransactionEdited = () => {
     if (params?.id) {
       const updatedCard = storage.getCard(params.id);
-      setCard(updatedCard || null);
+      // Create a new object to force a re-render
+      setCard(updatedCard ? { ...updatedCard, transactions: [...updatedCard.transactions] } : null);
     }
   };
 


### PR DESCRIPTION
The current balance was not being updated when a transaction was edited. This was caused by a React state mutation issue. The component was not re-rendering because the `setCard` function was being called with a mutated version of the same object, and React's shallow comparison did not detect the change.

This commit fixes the issue by creating a new card object before calling `setCard`. This ensures that React detects the state change and re-renders the component with the updated balance. The fix is applied to the `handleTransactionAdded`, `handleTransactionDeleted`, and `handleTransactionEdited` functions for consistency.