### PR TITLE
feat: Add PIN and barcode functionality to cards

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,0 +1,85 @@
+{
+  "name": "client",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "react-barcode": "^1.6.1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsbarcode": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/jsbarcode/-/jsbarcode-3.12.1.tgz",
+      "integrity": "sha512-QZQSqIknC2Rr/YOUyOkCBqsoiBAOTYK+7yNN3JsqfoUtJtkazxNw1dmPpxuv7VVvqW13kA3/mKiLq+s/e3o9hQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-barcode": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/react-barcode/-/react-barcode-1.6.1.tgz",
+      "integrity": "sha512-pc4ftnO5syHa/UjCruEeRsomlhoxKSugIgTA8T4dH0fvc89UMHL+/1Sp25IAphqG44pJkE5hMXhv89iS09jQyw==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbarcode": "^3.8.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "16 - 19"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react-barcode": "^1.6.1"
+  }
+}

--- a/client/src/components/add-card-modal.tsx
+++ b/client/src/components/add-card-modal.tsx
@@ -17,6 +17,7 @@ export default function AddCardModal({ isOpen, onClose, onCardAdded }: AddCardMo
   const [formData, setFormData] = useState<InsertCard>({
     name: "",
     number: "",
+    pin: "",
     initialValue: 0,
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -40,7 +41,7 @@ export default function AddCardModal({ isOpen, onClose, onCardAdded }: AddCardMo
     try {
       storage.addCard(result.data);
       onCardAdded();
-      setFormData({ name: "", number: "", initialValue: 0 });
+      setFormData({ name: "", number: "", pin: "", initialValue: 0 });
       setErrors({});
       toast({
         title: "Card Added",
@@ -88,6 +89,19 @@ export default function AddCardModal({ isOpen, onClose, onCardAdded }: AddCardMo
               className={errors.name ? "border-red-500" : ""}
             />
             {errors.name && <p className="text-sm text-red-500 mt-1">{errors.name}</p>}
+          </div>
+
+          <div>
+            <Label htmlFor="card-pin" className="text-sm font-medium text-gray-700 mb-2">
+              PIN (Optional)
+            </Label>
+            <Input
+              id="card-pin"
+              type="text"
+              value={formData.pin}
+              onChange={(e) => handleInputChange("pin", e.target.value)}
+              placeholder="e.g., 1234"
+            />
           </div>
 
           <div>

--- a/client/src/components/edit-card-modal.tsx
+++ b/client/src/components/edit-card-modal.tsx
@@ -22,6 +22,7 @@ interface EditCardModalProps {
 export default function EditCardModal({ card, isOpen, onClose, onCardUpdated }: EditCardModalProps) {
   const [name, setName] = useState("");
   const [number, setNumber] = useState("");
+  const [pin, setPin] = useState("");
   const [initialValue, setInitialValue] = useState("");
   const { toast } = useToast();
 
@@ -30,6 +31,7 @@ export default function EditCardModal({ card, isOpen, onClose, onCardUpdated }: 
     if (card && isOpen) {
       setName(card.name);
       setNumber(card.number || "");
+      setPin(card.pin || "");
       setInitialValue(card.initialValue.toString());
     }
   }, [card, isOpen]);
@@ -42,6 +44,7 @@ export default function EditCardModal({ card, isOpen, onClose, onCardUpdated }: 
     const updates = {
       name: name.trim(),
       number: number.trim() || undefined,
+      pin: pin.trim() || undefined,
       initialValue: parseFloat(initialValue)
     };
 
@@ -108,6 +111,17 @@ export default function EditCardModal({ card, isOpen, onClose, onCardUpdated }: 
               value={number}
               onChange={(e) => setNumber(e.target.value)}
               placeholder="e.g., 1234567890123456"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="pin">PIN (Optional)</Label>
+            <Input
+              id="pin"
+              type="text"
+              value={pin}
+              onChange={(e) => setPin(e.target.value)}
+              placeholder="e.g., 1234"
             />
           </div>
 

--- a/client/src/pages/card-detail.tsx
+++ b/client/src/pages/card-detail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useRoute, useLocation } from "wouter";
-import { ArrowLeft, Plus, CreditCard } from "lucide-react";
+import { ArrowLeft, Plus, CreditCard, KeyRound, Barcode as BarcodeIcon, QrCode } from "lucide-react";
+import Barcode from "react-barcode";
 import { Card } from "@shared/schema";
 import { storage } from "@/lib/storage";
 import TransactionItem from "@/components/transaction-item";
@@ -12,6 +13,7 @@ export default function CardDetail() {
   const [, setLocation] = useLocation();
   const [card, setCard] = useState<Card | null>(null);
   const [showAddModal, setShowAddModal] = useState(false);
+  const [showBarcode, setShowBarcode] = useState<"1d" | "qr" | null>(null);
 
   useEffect(() => {
     if (match && params?.id) {
@@ -109,7 +111,45 @@ export default function CardDetail() {
             <p className="text-lg font-medium">${card.initialValue.toFixed(2)}</p>
           </div>
         </div>
+
+        {(card.pin || card.number) && (
+          <div className="mt-4 pt-4 border-t border-white border-opacity-20 flex items-center justify-between">
+            {card.pin && (
+              <div className="flex items-center">
+                <KeyRound className="w-5 h-5 mr-2" />
+                <p className="text-lg font-mono">{card.pin}</p>
+              </div>
+            )}
+            {card.number && (
+              <div className="flex gap-2">
+                <Button variant="ghost" size="sm" onClick={() => setShowBarcode("1d")} className="p-2 h-auto rounded-md bg-white bg-opacity-20 hover:bg-opacity-30">
+                  <BarcodeIcon className="w-6 h-6" />
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => setShowBarcode("qr")} className="p-2 h-auto rounded-md bg-white bg-opacity-20 hover:bg-opacity-30">
+                  <QrCode className="w-6 h-6" />
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
+
+      {showBarcode && card.number && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center"
+          onClick={() => setShowBarcode(null)}
+        >
+          <div className="bg-white p-8 rounded-lg" onClick={(e) => e.stopPropagation()}>
+            <Barcode
+              value={card.number}
+              format={showBarcode === "qr" ? "QRCODE" : "CODE128"}
+              width={showBarcode === '1d' ? 2 : 1}
+              height={showBarcode === '1d' ? 100 : undefined}
+              displayValue={true}
+            />
+          </div>
+        </div>
+      )}
 
       {/* Transaction List */}
       <div className="p-4 pb-20">

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const insertCardSchema = z.object({
   name: z.string().min(1, "Card name is required"),
   number: z.string().optional(),
+  pin: z.string().optional(),
   initialValue: z.number().min(0, "Initial value must be positive"),
 });
 


### PR DESCRIPTION
This commit introduces two new features:
- An optional PIN field for each card.
- A barcode/QR code display for the card number.

The following changes were made:
- The card schema in `shared/schema.ts` was updated to include an optional `pin` field.
- The "Add Card" and "Edit Card" modals were updated to include an input for the PIN.
- The card detail view was updated to display the PIN and to show a barcode or QR code for the card number.
- The `react-barcode` library was added to generate the barcodes.

Note: Manual testing was not possible due to issues with starting the development server.