### PR TITLE
fix: Correct QR code display

### DIFF
--- a/client/src/pages/card-detail.tsx
+++ b/client/src/pages/card-detail.tsx
@@ -143,7 +143,7 @@ export default function CardDetail() {
             <Barcode
               value={card.number}
               format={showBarcode === "qr" ? "QRCODE" : "CODE128"}
-              width={showBarcode === '1d' ? 2 : 1}
+              width={showBarcode === '1d' ? 2 : undefined}
               height={showBarcode === '1d' ? 100 : undefined}
               displayValue={true}
             />


### PR DESCRIPTION
The QR code was not rendering because the `width` prop was set to 1. This commit removes the `width` and `height` props when rendering a QR code, allowing the `react-barcode` library to use its default sizing.