### PR TITLE
fix: Set explicit size for QR code

### DIFF
--- a/client/src/pages/card-detail.tsx
+++ b/client/src/pages/card-detail.tsx
@@ -143,8 +143,8 @@ export default function CardDetail() {
             <Barcode
               value={card.number}
               format={showBarcode === "qr" ? "QRCODE" : "CODE128"}
-              width={showBarcode === '1d' ? 2 : undefined}
-              height={showBarcode === '1d' ? 100 : undefined}
+              width={showBarcode === '1d' ? 2 : 256}
+              height={showBarcode === '1d' ? 100 : 256}
               displayValue={true}
             />
           </div>


### PR DESCRIPTION
The QR code was rendering as an empty SVG. This was likely due to the `react-barcode` library requiring an explicit size for QR codes.

This commit sets the `width` and `height` of the QR code to 256px to ensure it renders correctly.